### PR TITLE
/api/events-GET-Request

### DIFF
--- a/src/app/api/events/route.js
+++ b/src/app/api/events/route.js
@@ -1,0 +1,34 @@
+import { getRecords } from '../../services/airtable';
+
+export async function GET() {
+	try {
+		//fetch records --> airtable calls their entries 'records' so for clarity we too will use {records}. Here, records = events
+		const { records: events } = await getRecords({
+			tableName: 'Events',
+			filters: `{Status} = "Approved"`,
+		});
+		//if successful return in response
+		return new Response(JSON.stringify(events), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' },
+		});
+		//if issue then ---> console.log the error with records(events)for debugging
+	} catch (error) {
+		console.error(
+			`Encountered ${error} when trying to fetch records from Airtable`
+		);
+		//generic failure message to the client/frontend.
+		return new Response(
+			JSON.stringify({
+				error: 'Failed to fetch events',
+			}),
+			{ status: 500 }
+		);
+	}
+}
+
+/*
+Cleaner but no error handling
+	const { records } = await getRecords({ tableName: 'Events' });
+	return Response.json(records);
+*/


### PR DESCRIPTION
GET route that fetches event records from Airtable. Uses Airtable’s `filterByFormula` to include only those where the event `Status` is "`Approved`".